### PR TITLE
Add license check CI and update README

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+
+# Copyright (C) 2021  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier:	ISC
+
+name: Basic-SymbiFlow-CI
+
+# Controls when the workflow will run
+on: [push, pull_request]
+
+jobs:     
+  SymbiFlowBasicChecks:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Getting code
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Getting code
+      uses: SymbiFlow/actions/checks@main

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ This repository will hold the following items:
   * [x] `.editorconfig` file 
     * [ ] Fully implemented
   * [x] Copyright / license
-    * [ ] Fully implemented
+    * [x] Fully implemented
   * [x]  Auto-formatting tools - `clang-format`, `yapf`, `verible`, `mjson`
     * [x] Fully implemented
 * [ ] Documentation around policies


### PR DESCRIPTION
This script checks basic license information and python header info. See [https://github.com/SymbiFlow/actions/tree/main/checks](https://github.com/SymbiFlow/actions/tree/main/checks) for details.