### PR TITLE
Add merger scripts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,8 @@ To learn more, see [Issue 51](https://github.com/SymbiFlow/ideas/issues/51) on t
 
 [Sphinx Setup](#sphinx)
 
+[Integrating With Other Repositories](#integration)
+
 ---
 
 ### <a name="progress"/> Progress
@@ -87,3 +89,9 @@ These will be used automatically upon PR/Issue creation. Proper labels will also
 ---
 
 ## <a name="sphinx"/> Sphinx Setup
+
+## <a name="integration"/> Integration With Other Repositories 
+
+Adding `common-config` as a subtree to all other repositories will be handled with the `merger.sh` and `merger_help.py` scripts.
+
+Updates to `common-config` files should be made to this repository, then pulled in to other repositories with `git subtree pull`.

--- a/merger.sh
+++ b/merger.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
-
-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier:	ISC
 
 mkdir tmp-clone
 cd tmp-clone

--- a/merger.sh
+++ b/merger.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+
+
+mkdir tmp-clone
+cd tmp-clone
+
+read -p "This will create many pull requests. Are you sure you want to continue? (y/n) "  -r
+echo
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+  kill -INT $$
+fi
+
+
+echo "Clone repos"
+curl -s https://api.github.com/orgs/SymbiFlow/repos?per_page=200 | python ../merger_help.py 
+
+echo "Repos cloned"
+for dir in ./* ; do
+  if [ -d "$dir" ]; then
+    dir=${dir%*/}
+
+    echo "Adding Subtree"
+    cd ${dir##*/}
+    git checkout -b add-common-config
+    git subtree add --prefix third_party/common-config https://github.com/SymbiFlow/common-config.git main --squash
+
+    shopt -s dotglob
+    mv third_party/common-config/formatter-files/* .
+    mv third_party/common-config/LICENSE .
+    mv third_party/common-config/docs/* ./docs
+    mv third_party/common-config/.github/ISSUE_TEMPLATE/* ./.github/ISSUE_TEMPLATE
+    mv third_party/common-config/.github/workflows/* ./.github/workflows
+    mv third_party/common-config/.github/pull_request_template.md ./.github
+    git add .
+    git commit -m "Add common-config repo as subtree"
+    git push
+    gh pr create --repo Symbiflow/${dir##*/} --title "Add common-config repo as subtree" --body "Add common-config repo as subtree under third_party directory. Files are also copied to their required locations in docs, .github, etc."
+    cd ..
+  fi
+done

--- a/merger_help.py
+++ b/merger_help.py
@@ -1,3 +1,13 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2021  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier:	ISC
 import sys;
 import json;
 import os;

--- a/merger_help.py
+++ b/merger_help.py
@@ -1,0 +1,7 @@
+import sys;
+import json;
+import os;
+json_arr = json.load(sys.stdin)
+for val in json_arr:
+    url = val['clone_url']
+    os.system("gh repo fork {} --clone".format(url))


### PR DESCRIPTION
Included the two scripts necessary to add common-config as a subtree to other SymbiFlow repositories. Also added a brief section in the README describing these files.