### PR TITLE
Add update_subtree script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,3 +80,11 @@ master:
 
     git rebase --signoff upstream/master
 
+### Updating Common-Config
+
+The [symbiflow-common-config](https://github.com/SymbiFlow/symbiflow-common-config) repository contains files that should remain consitent across SymbiFlow owned repositories (editor/code formatter files, community health files, Sphinx setup, etc)
+
+Should you desire to update files that belong to this repository, you should submit a pull request to the repository linked above.
+
+To pull in new upates from `symbiflow-common-config` to any repository that contains it, run the `update_subtree.sh` script, which will pull in new changes and move new files to their proper location.
+

--- a/merger.sh
+++ b/merger.sh
@@ -30,7 +30,7 @@ for dir in ./* ; do
     echo "Adding Subtree"
     cd ${dir##*/}
     git checkout -b add-common-config
-    git subtree add --prefix third_party/common-config https://github.com/SymbiFlow/common-config.git main --squash
+    git subtree add --prefix third_party/common-config https://github.com/SymbiFlow/symbiflow-common-config.git main --squash
 
     #Make necessary directories
     shopt -s dotglob

--- a/update_subtree.sh
+++ b/update_subtree.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier:	ISC
+
+git subtree pull --prefix third_party/common-config https://github.com/SymbiFlow/symbiflow-common-config.git main subtree-script --squash
+
+#Make necessary directories
+shopt -s dotglob
+dirs=`find -type d -path "*third_party/common-config*" -not -path "./.git/*" -not -path "./.git"`
+for dir in $dirs
+do
+  mkdir ${dir##*common-config/}
+done
+mkdir orig
+
+#Copy old files and replace with common-config
+files=`find -type f -path "*third_party/common-config*" -not -name "merger*" -not -path "./.git/*"`
+for file in $files
+do
+  [[ -f ${file##*common-config/} ]] && cp ${file##*common-config/} "orig/${file##*/}-orig"
+  filedir="$(dirname $file)"
+  mv $file .${filedir##*common-config}
+done
+
+


### PR DESCRIPTION
Not sure if this is the right solution, but this is a way we could handle pulling in updates from common-config on each repository.

Essentially after common config is added, each repository would have access to an `update-subtree.sh` file, which when ran, will pull in changes from the original `symbiflow-common-config` repository and then as before, make sure all of the files are in the correct location. (This is necessary because if a new file is to common-config, when those changes are pulled into another repository, it will leave it in third_party/common-config, where it will not be able to function).

I've also added a brief section to `CONTRIBUTING.md` explaining how this works.

I think this solution is acceptable for the moment, as it allows repositories to be updated individually, so no one is forced to receive incoming changes.